### PR TITLE
Fix ruby-saml version to 0.9.2

### DIFF
--- a/devise_saml_authenticatable.gemspec
+++ b/devise_saml_authenticatable.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |gem|
   gem.version       = DeviseSamlAuthenticatable::VERSION
   
   gem.add_dependency("devise","> 2.0.0")
-  gem.add_dependency("ruby-saml",">= 0.8.1")
+  gem.add_dependency("ruby-saml","0.9.2")
 end

--- a/lib/devise_saml_authenticatable/version.rb
+++ b/lib/devise_saml_authenticatable/version.rb
@@ -1,3 +1,3 @@
 module DeviseSamlAuthenticatable
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
Due to breaking version of 1.0.0: https://github.com/apokalipto/devise_saml_authenticatable/commit/5b9a9ead571ba9635e990fda65160e0fe9d68cbf

@joakimlagergren kan du kika på detta?
